### PR TITLE
make sure to not export private API

### DIFF
--- a/sunshine.py
+++ b/sunshine.py
@@ -1,9 +1,13 @@
+__all__ = [
+  # This modulde does not export any symbols; all sumbols are private/internal.
+]
+
+
 import json
 import argparse
 import os
 import html
 import copy
-
 
 VERSION = "0.9"
 NAME = "Sunshine"


### PR DESCRIPTION
this tool provides a CLI, not an API.
therefore, all symbols are intended as private/internal. 



this is a technical measure to prevent downstream users from abuse and false expectations. 