### PR TITLE
Add argument to prevent the display of the logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ options:
   -c, --min-cvss MIN_CVSS                 show only vulnerabilities with score equal to or greater than the selected value, which can be in rage 0.0-10.0
   -p, --min-epss MIN_EPSS                 show only vulnerabilities with EPSS equal to or greater than the selected value, which can be in rage 0.00-1.00
   -n, --no-segment-limit                  prevent the automatic conversion of charts with many segments into still images
+  -nl, --no-logo                          prevent the display of the banner logo on startup
 ```
 
 <br>

--- a/sunshine.py
+++ b/sunshine.py
@@ -2299,13 +2299,6 @@ def main_web(input_string, enrich_cves, only_in_cisa_kev, only_critical_severity
 
 
 if __name__ == "__main__":
-    custom_print(f'''
- ▗▄▄▖▗▖ ▗▖▗▖  ▗▖ ▗▄▄▖▗▖ ▗▖▗▄▄▄▖▗▖  ▗▖▗▄▄▄▖
-▐▌   ▐▌ ▐▌▐▛▚▖▐▌▐▌   ▐▌ ▐▌  █  ▐▛▚▖▐▌▐▌   
- ▝▀▚▖▐▌ ▐▌▐▌ ▝▜▌ ▝▀▚▖▐▛▀▜▌  █  ▐▌ ▝▜▌▐▛▀▀▘
-▗▄▄▞▘▝▚▄▞▘▐▌  ▐▌▗▄▄▞▘▐▌ ▐▌▗▄█▄▖▐▌  ▐▌▐▙▄▄▖
-    ''')
-
     parser = argparse.ArgumentParser(description=f"{NAME}: actionable CycloneDX visualization")
     parser.add_argument("-i", "--input", help="path of input CycloneDX file")
     parser.add_argument("-o", "--output", help="path of output HTML file")
@@ -2324,7 +2317,17 @@ if __name__ == "__main__":
 
     parser.add_argument("-n", "--no-segment-limit", help="prevent the automatic conversion of charts with many segments into still images", action="store_true")
 
+    parser.add_argument("-nl", "--no-logo", help="prevent the display of the banner logo on startup", action="store_true")
+
     args = parser.parse_args()
+    
+    if not args.no_logo:
+        custom_print(f'''
+ ▗▄▄▖▗▖ ▗▖▗▖  ▗▖ ▗▄▄▖▗▖ ▗▖▗▄▄▄▖▗▖  ▗▖▗▄▄▄▖
+▐▌   ▐▌ ▐▌▐▛▚▖▐▌▐▌   ▐▌ ▐▌  █  ▐▛▚▖▐▌▐▌   
+ ▝▀▚▖▐▌ ▐▌▐▌ ▝▜▌ ▝▀▚▖▐▛▀▜▌  █  ▐▌ ▝▜▌▐▛▀▀▘
+▗▄▄▞▘▝▚▄▞▘▐▌  ▐▌▗▄▄▞▘▐▌ ▐▌▗▄█▄▖▐▌  ▐▌▐▙▄▄▖
+        ''')
 
     if not args.input or not args.output:
         parser.print_help()


### PR DESCRIPTION
Added an argument to suppress display of the ASCII art "SUNSHINE" logo.

This is to address an issue I was having as described here: https://github.com/CycloneDX/Sunshine/issues/19

Note: this is my second attempt. In my first attempt I failed the DCO test because I didn't sign the commit.